### PR TITLE
Debug mux config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -1,70 +1,203 @@
-Protocentral ADS1293, 3-Channel, 24-Bit ECG breakout board
-================================
+# Protocentral ADS1293 Arduino Library
 
-[![Compile Examples](https://github.com/Protocentral/protocentral-ads1293-arduino/workflows/Compile%20Examples/badge.svg)](https://github.com/Protocentral/protocentral-ads1293-arduino/actions?workflow=Compile+Examples) 
+[![Compile Examples](https://github.com/Protocentral/protocentral-ads1293-arduino/workflows/Compile%20Examples/badge.svg)](https://github.com/Protocentral/protocentral-ads1293-arduino/actions?workflow=Compile+Examples)
+
+Arduino library for the Protocentral ADS1293 3-channel, 24-bit ECG breakout board.
 
 ## Don't have one? [Buy it here](https://protocentral.com/product/protocentral-ads1293-breakout-board/)
 
-![ADS1293 Breakout](/docs/assets/product_image.jpg) 
+![ADS1293 Breakout](/docs/assets/product_image.jpg)
 
-The ADS1293 incorporates all features commonly required in portable, low-power medical, sports, and fitness electrocardiogram (ECG) applications. The ADS1293 features three high-resolution channels, each channel can be independently programmed for a specific sample rate and bandwidth allowing users to optimize the configuration for performance and power. A fourth channel allows external analog pace detection for applications that do not use digital pace detection.
+The ADS1293 is a low-power, 3-channel, 24-bit analog front-end for biopotential measurements, ideal for ECG applications. It features independently programmable channels, flexible input multiplexing, Right Leg Drive (RLD), Wilson Central Terminal (WCT) for precordial leads, and lead-off detection.
 
-The ADS1293 incorporates a self-diagnostics alarm
-system to detect when the system is out of the operating conditions range. 
+## Features
 
+- 3 high-resolution 24-bit sigma-delta ADC channels
+- Configurable sampling rates (32 to 853 SPS)
+- Support for 3-lead and 5-lead ECG configurations
+- Built-in Right Leg Drive (RLD) amplifier
+- Wilson Central Terminal for precordial lead measurements
+- SPI interface
+
+## Installation
+
+### Arduino Library Manager (Recommended)
+1. Open Arduino IDE
+2. Go to **Sketch → Include Library → Manage Libraries**
+3. Search for "Protocentral ADS1293"
+4. Click **Install**
+
+### Manual Installation
+1. Download or clone this repository
+2. Copy to your Arduino libraries folder (`~/Documents/Arduino/libraries/`)
 
 ## Hardware Setup
-Connection with the Arduino board is as follows:
 
-|ADS1293 pin label| Arduino Connection  |Pin Function      |
- |:-----------------: |:---------------------:|:------------------:|
- | MISO             | 12  |Slave Out            | 
-| MOSI             | 11      | Slave In             |
-| SCLK             | 13 | Serial Clock         |  
-| CS               | 10 | Chip Select          |  
-| Vcc              | +5V | Power          |  
-| GND              | GND | GND          | 
-| DRDY             | 02 | Data ready           | 
+### Pin Connections
 
+| Signal | Arduino UNO | ESP32 (VSPI) |
+|--------|-------------|--------------|
+| MISO   | 12          | 19           |
+| MOSI   | 11          | 23           |
+| SCLK   | 13          | 18           |
+| CS     | 4           | 4            |
+| DRDY   | 2           | 2            |
+| VCC    | 5V          | 5V           |
+| GND    | GND         | GND          |
+
+### ECG Electrode Input Mapping
+
+The ADS1293 has 6 input pins (IN1-IN6) that connect to ECG electrodes:
+
+| Input | Electrode | Description |
+|-------|-----------|-------------|
+| IN1   | RA        | Right Arm   |
+| IN2   | LA        | Left Arm    |
+| IN3   | LL        | Left Leg    |
+| IN4   | RL        | Right Leg (RLD driven) |
+| IN5   | V1        | Precordial lead (5-lead only) |
+| IN6   | WCT       | Wilson Central Terminal reference |
+
+### Lead Configuration
+
+**3-Lead ECG (Einthoven's Triangle):**
+- Channel 1: Lead I = LA - RA (IN2 - IN1)
+- Channel 2: Lead II = LL - RA (IN3 - IN1)
+- Lead III is calculated: Lead III = Lead II - Lead I
+
+**5-Lead ECG (adds precordial lead):**
+- Channel 1: Lead I = LA - RA
+- Channel 2: Lead II = LL - RA
+- Channel 3: V1 = IN5 - WCT (Wilson Central Terminal)
+
+## Quick Start
+
+### 3-Lead ECG Example
+
+```cpp
+#include "protocentral_ads1293.h"
+#include <SPI.h>
+
+#define DRDY_PIN 2
+#define CS_PIN 4
+
+ADS1293 ecg(DRDY_PIN, CS_PIN);
+
+void setup() {
+    Serial.begin(115200);
+    ecg.begin();
+
+    // Configure for 3-lead ECG
+    ecg.configureChannel1(FlexCh1Mode::Default);  // Lead I: LA-RA
+    ecg.configureChannel2(FlexCh2Mode::Default);  // Lead II: LL-RA
+    ecg.enableCommonModeDetection(CMDetMode::Enabled);
+    ecg.configureRLD(RLDMode::Default);
+    ecg.configureOscillator(OscMode::Default);
+    ecg.configureAFEShutdown(AFEShutdownMode::AllEnabled);
+    ecg.setSamplingRate(ADS1293::SamplingRate::SPS_128);
+    ecg.configureDRDYSource(DRDYSource::Default);
+    ecg.configureChannelConfig(ChannelConfig::Default3Lead);
+    ecg.applyGlobalConfig(GlobalConfig::Start);
+}
+
+void loop() {
+    if (ecg.isDataReady()) {
+        auto samples = ecg.getECGData();
+        if (samples.ok) {
+            Serial.print(samples.ch1);
+            Serial.print(',');
+            Serial.print(samples.ch2);
+            Serial.print(',');
+            Serial.println(samples.ch3);
+        }
+    }
+}
+```
+
+### ESP32 Setup
+
+For ESP32, use the `begin()` overload with SPI pin parameters:
+
+```cpp
+#define SCK_PIN 18
+#define MISO_PIN 19
+#define MOSI_PIN 23
+
+ecg.begin(SCK_PIN, MISO_PIN, MOSI_PIN);
+```
+
+## API Reference
+
+### Constructor
+
+```cpp
+ADS1293(uint8_t drdyPin, uint8_t csPin, SPIClass *spi = &SPI)
+```
+
+### Initialization
+
+| Method | Description |
+|--------|-------------|
+| `begin()` | Initialize with default SPI |
+| `begin(sck, miso, mosi)` | Initialize with custom SPI pins (ESP32) |
+
+### Data Reading
+
+| Method | Description |
+|--------|-------------|
+| `isDataReady()` | Returns `true` if new samples are available |
+| `getECGData()` | Returns `Samples` struct with `ch1`, `ch2`, `ch3`, and `ok` flag |
+| `getECGData(ch1, ch2, ch3)` | Reads samples into reference parameters |
+
+### Configuration
+
+| Method | Description |
+|--------|-------------|
+| `configureChannel1(mode)` | Configure channel 1 input mux |
+| `configureChannel2(mode)` | Configure channel 2 input mux |
+| `configureChannel3(mode)` | Configure channel 3 input mux |
+| `enableCommonModeDetection(mode)` | Enable common-mode detection |
+| `configureRLD(mode)` | Configure Right Leg Drive |
+| `configureWilsonCentralTerminal()` | Enable WCT for 5-lead ECG |
+| `setSamplingRate(rate)` | Set output data rate |
+| `configureAFEShutdown(mode)` | Control AFE power |
+| `applyGlobalConfig(mode)` | Start/stop conversions |
+
+### Sampling Rates
+
+```cpp
+ADS1293::SamplingRate::SPS_32   // 32 samples/sec
+ADS1293::SamplingRate::SPS_64   // 64 samples/sec
+ADS1293::SamplingRate::SPS_128  // 128 samples/sec
+ADS1293::SamplingRate::SPS_256  // 256 samples/sec
+ADS1293::SamplingRate::SPS_512  // ~533 samples/sec
+ADS1293::SamplingRate::SPS_853  // ~1066 samples/sec
+```
+
+## Examples
+
+| Example | Description |
+|---------|-------------|
+| `01-3-lead-ECG-stream` | Stream 3-lead ECG to Arduino Serial Plotter |
+| `02-5-lead-ECG-stream` | Stream 5-lead ECG with precordial lead |
+| `03-5-lead-ECG-openview` | 5-lead ECG with Protocentral OpenView protocol |
 
 ## Visualizing Output
 
+Use the Arduino Serial Plotter or [Protocentral OpenView](https://github.com/Protocentral/protocentral_openview) to visualize ECG waveforms.
+
 ![streaming](./docs/assets/output.gif)
 
+## Documentation
 
-## For further details, refer [the documentation on ADS1293 breakout board](https://docs.protocentral.com/getting-started-with-ADS1293/)
+For detailed hardware information and application notes, see the [ADS1293 breakout board documentation](https://docs.protocentral.com/getting-started-with-ADS1293/).
 
-
-License Information
-===================
+## License
 
 ![License](license_mark.svg)
 
-This product is open source! Both, our hardware and software are open source and licensed under the following licenses:
+**Hardware:** [Creative Commons Share-alike 4.0 International](http://creativecommons.org/licenses/by-sa/4.0/) ![CC-BY-SA-4.0](https://i.creativecommons.org/l/by-sa/4.0/88x31.png)
 
-Hardware
----------
+**Software:** [MIT License](http://opensource.org/licenses/MIT)
 
-**All hardware is released under [Creative Commons Share-alike 4.0 International](http://creativecommons.org/licenses/by-sa/4.0/).**
-![CC-BY-SA-4.0](https://i.creativecommons.org/l/by-sa/4.0/88x31.png)
-
-You are free to:
-
-* Share — copy and redistribute the material in any medium or format
-* Adapt — remix, transform, and build upon the material for any purpose, even commercially.
-The licensor cannot revoke these freedoms as long as you follow the license terms.
-
-Under the following terms:
-
-* Attribution — You must give appropriate credit, provide a link to the license, and indicate if changes were made. You may do so in any reasonable manner, but not in any way that suggests the licensor endorses you or your use.
-* ShareAlike — If you remix, transform, or build upon the material, you must distribute your contributions under the same license as the original.
-
-Software
---------
-
-**All software is released under the MIT License(http://opensource.org/licenses/MIT).**
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-
-Please check [*LICENSE.md*](LICENSE.md) for detailed license descriptions.
+See [LICENSE.md](LICENSE.md) for details.

--- a/examples/01-3-lead-ECG-stream/01-3-lead-ECG-stream.ino
+++ b/examples/01-3-lead-ECG-stream/01-3-lead-ECG-stream.ino
@@ -2,28 +2,30 @@
 //
 //  Protocentral ADS1293 Arduino example — 3-lead ECG (Arduino Plotter)
 //
-//  Author: Ashwin Whitchurch, Protocentral Electronics
-//  SPDX-FileCopyrightText: 2025 Protocentral Electronics
+//  Author: Ashwin Whitchurch
+//  Copyright (c) 2020-2025 Protocentral Electronics
+//
 //  SPDX-License-Identifier: MIT
 //
-//  This example streams ECG samples to the Arduino IDE Plotter.
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
-//  Hardware connections (Arduino UNO / ESP32 VSPI):
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
-//  | Signal | Arduino UNO | ESP32 (VSPI default) |
-//  |-------:|:-----------:|:--------------------:|
-//  | MISO   | 12          | 19                   |
-//  | MOSI   | 11          | 23                   |
-//  | SCLK   | 13          | 18                   |
-//  | CS     | 4           | 4                    |
-//  | VCC    | +5V         | +5V                  |
-//  | GND    | GND         | GND                  |
-//  | DRDY   | 2           | 2                    |
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 //
-//  For full documentation and examples, see:
-//    https://github.com/Protocentral/protocentral-ads1293-arduino
-//
-/////////////////////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////////////////
 
 #include "protocentral_ads1293.h"
 #include <SPI.h>
@@ -63,14 +65,8 @@ void setup()
 	ADS1293.enableCommonModeDetection(CMDetMode::Enabled);
 	ADS1293.configureRLD(RLDMode::Default);
 	ADS1293.configureOscillator(OscMode::Default);
-
-	ADS1293.configureAFEShutdown(AFEShutdownMode::AFE_On);
-	ADS1293.setSamplingRate(ADS1293::SamplingRate::SPS_100);
-
-	ADS1293.setChannelGain(1, ADS1293::PgaGain::G8);
-	ADS1293.setChannelGain(2, ADS1293::PgaGain::G8);
-	ADS1293.setChannelGain(3, ADS1293::PgaGain::G8);
-
+	ADS1293.configureAFEShutdown(AFEShutdownMode::AllEnabled);
+	ADS1293.setSamplingRate(ADS1293::SamplingRate::SPS_128);
 	ADS1293.configureDRDYSource(DRDYSource::Default);
 	ADS1293.configureChannelConfig(ChannelConfig::Default3Lead);
 	ADS1293.applyGlobalConfig(GlobalConfig::Start);
@@ -80,7 +76,8 @@ void setup()
 
 void loop()
 {
-	if (digitalRead(DRDY_PIN) == LOW)
+	// Poll DATA_STATUS register to check if new data is available
+	if (ADS1293.isDataReady())
 	{
 		auto samples = ADS1293.getECGData();
 		if (samples.ok)
@@ -92,5 +89,4 @@ void loop()
 			Serial.println(samples.ch3);
 		}
 	}
-	delay(10);
 }

--- a/examples/02-5-lead-ECG-stream/02-5-lead-ECG-stream.ino
+++ b/examples/02-5-lead-ECG-stream/02-5-lead-ECG-stream.ino
@@ -2,28 +2,30 @@
 //
 //  Protocentral ADS1293 Arduino example — 5-lead ECG (Arduino Plotter)
 //
-//  Author: Ashwin Whitchurch, Protocentral Electronics
-//  SPDX-FileCopyrightText: 2025 Protocentral Electronics
+//  Author: Ashwin Whitchurch
+//  Copyright (c) 2020-2025 Protocentral Electronics
+//
 //  SPDX-License-Identifier: MIT
 //
-//  This example streams ECG samples to the Arduino IDE Plotter.
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
-//  Hardware connections (Arduino UNO / ESP32 VSPI):
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
-//  | Signal | Arduino UNO | ESP32 (VSPI default) |
-//  |-------:|:-----------:|:--------------------:|
-//  | MISO   | 12          | 19                   |
-//  | MOSI   | 11          | 23                   |
-//  | SCLK   | 13          | 18                   |
-//  | CS     | 4           | 4                    |
-//  | VCC    | +5V         | +5V                  |
-//  | GND    | GND         | GND                  |
-//  | DRDY   | 2           | 2                    |
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 //
-//  For full documentation and examples, see:
-//    https://github.com/Protocentral/protocentral-ads1293-arduino
-//
-/////////////////////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////////////////
 
 #include "protocentral_ads1293.h"
 #include <SPI.h>
@@ -61,23 +63,21 @@ void setup()
 	ADS1293.configureChannel3(FlexCh3Mode::Default);
 	ADS1293.enableCommonModeDetection(CMDetMode::Enabled);
 	ADS1293.configureRLD(RLDMode::Default);
-	ADS1293.configureRef(RefMode::Default);
+	ADS1293.configureWilsonCentralTerminal();  // Required for 5-lead ECG
 	ADS1293.configureOscillator(OscMode::Default);
-	ADS1293.configureAFEShutdown(AFEShutdownMode::AFE_On);
-
-	ADS1293.setSamplingRate(ADS1293::SamplingRate::SPS_100);
-	ADS1293.setChannelGain(1, ADS1293::PgaGain::G8);
-	ADS1293.setChannelGain(2, ADS1293::PgaGain::G8);
-	ADS1293.setChannelGain(3, ADS1293::PgaGain::G8);
+	ADS1293.configureAFEShutdown(AFEShutdownMode::AllEnabled);
+	ADS1293.setSamplingRate(ADS1293::SamplingRate::SPS_128);
 	ADS1293.configureDRDYSource(DRDYSource::Default);
 	ADS1293.configureChannelConfig(ChannelConfig::Default5Lead);
 	ADS1293.applyGlobalConfig(GlobalConfig::Start);
+
 	delay(10);
 }
 
 void loop()
 {
-	if (digitalRead(DRDY_PIN) == LOW)
+	// Poll DATA_STATUS register to check if new data is available
+	if (ADS1293.isDataReady())
 	{
 		auto samples = ADS1293.getECGData();
 		if (samples.ok)
@@ -89,5 +89,4 @@ void loop()
 			Serial.println(samples.ch3);
 		}
 	}
-	delay(15);
 }

--- a/examples/03-5-lead-ECG-openview/03-5-lead-ECG-openview.ino
+++ b/examples/03-5-lead-ECG-openview/03-5-lead-ECG-openview.ino
@@ -2,30 +2,30 @@
 //
 //  Protocentral ADS1293 Arduino example — 5-lead ECG (OpenView packet format)
 //
-//  Author: Ashwin Whitchurch, Protocentral Electronics
-//  SPDX-FileCopyrightText: 2025 Protocentral Electronics
+//  Author: Ashwin Whitchurch
+//  Copyright (c) 2020-2025 Protocentral Electronics
+//
 //  SPDX-License-Identifier: MIT
 //
-//  Streams ECG samples in the OpenView packet format. See the OpenView
-//  project for the host-side processing tools:
-//    https://github.com/Protocentral/protocentral_openview
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
-//  Hardware connections (Arduino UNO / ESP32 VSPI):
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
-//  | Signal | Arduino UNO | ESP32 (VSPI default) |
-//  |-------:|:-----------:|:--------------------:|
-//  | MISO   | 12          | 19                   |
-//  | MOSI   | 11          | 23                   |
-//  | SCLK   | 13          | 18                   |
-//  | CS     | 4           | 4                    |
-//  | VCC    | +5V         | +5V                  |
-//  | GND    | GND         | GND                  |
-//  | DRDY   | 2           | 2                    |
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 //
-//  For full documentation and examples, see:
-//    https://github.com/Protocentral/protocentral-ads1293-arduino
-//
-/////////////////////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////////////////
 
 
 #include "protocentral_ads1293.h"
@@ -40,9 +40,6 @@
 
 #define DRDY_PIN 2
 #define CS_PIN 4
-
-// Uncomment to send voltages instead of raw ADC codes
-// #define PRINT_VOLTAGE
 
 // Optional SPI pin overrides
 #if !defined(SCK_PIN)
@@ -96,23 +93,6 @@ void sendDataThroughUart(int32_t ecgCh1, int32_t ecgCh2, int32_t ecgCh3) {
 	}
 }
 
-// Helper: convert 24-bit unsigned raw value to signed 32-bit using two's-complement
-static int32_t raw24_to_int24(uint32_t raw24) {
-	raw24 &= 0xFFFFFFu;
-	if (raw24 & 0x800000u) {
-		return static_cast<int32_t>(raw24 | 0xFF000000u);
-	}
-	return static_cast<int32_t>(raw24);
-}
-
-// Helper: build a 24-bit raw value from three bytes (MSB, mid, LSB)
-static uint32_t raw24_from_bytes(uint8_t msb, uint8_t mid, uint8_t lsb) {
-	return (static_cast<uint32_t>(msb) << 16) | (static_cast<uint32_t>(mid) << 8) | static_cast<uint32_t>(lsb);
-}
-
-// Uncomment to enable debug register/sample dumps on startup
-// #define ENABLE_DEBUG
-
 void setup() {
 	Serial.begin(57600);
 #if defined(ARDUINO_ARCH_ESP32)
@@ -126,40 +106,22 @@ void setup() {
 	ADS1293.configureChannel3(FlexCh3Mode::Default);
 	ADS1293.enableCommonModeDetection(CMDetMode::Enabled);
 	ADS1293.configureRLD(RLDMode::Default);
-	ADS1293.configureRef(RefMode::Default);
+	ADS1293.configureWilsonCentralTerminal();  // Required for 5-lead ECG
 	ADS1293.configureOscillator(OscMode::Default);
-	ADS1293.configureAFEShutdown(AFEShutdownMode::AFE_On);
-
-	ADS1293.setSamplingRate(ADS1293::SamplingRate::SPS_100);
-	ADS1293.setChannelGain(1, ADS1293::PgaGain::G8);
-	ADS1293.setChannelGain(2, ADS1293::PgaGain::G8);
-	ADS1293.setChannelGain(3, ADS1293::PgaGain::G8);
+	ADS1293.configureAFEShutdown(AFEShutdownMode::AllEnabled);
+	ADS1293.setSamplingRate(ADS1293::SamplingRate::SPS_128);
 	ADS1293.configureDRDYSource(DRDYSource::Default);
 	ADS1293.configureChannelConfig(ChannelConfig::Default5Lead);
 	ADS1293.applyGlobalConfig(GlobalConfig::Start);
-	delay(10);
 
-#if defined(ENABLE_DEBUG)
-	ADS1293.dumpDebug(Serial);
-#endif
+	delay(10);
 }
 
 void loop() {
-	if (digitalRead(DRDY_PIN) == LOW) {
-		// Use convenience overload to get all three channels in one call
+	if (ADS1293.isDataReady()) {
 		auto samples = ADS1293.getECGData();
 		if (samples.ok) {
-				// Read raw 24-bit values from the device, sign-extend to int32_t,
-				// and send as 32-bit little-endian (LSB first) in the packet payload.
-				uint32_t raw1 = 0, raw2 = 0, raw3 = 0;
-				if (ADS1293.getRaw24(1, raw1) && ADS1293.getRaw24(2, raw2) && ADS1293.getRaw24(3, raw3)) {
-					int32_t s1 = raw24_to_int24(raw1);
-					int32_t s2 = raw24_to_int24(raw2);
-					int32_t s3 = raw24_to_int24(raw3);
-					sendDataThroughUart(s1, s2, s3);
-				}
+			sendDataThroughUart(samples.ch1, samples.ch2, samples.ch3);
 		}
 	}
-	delay(10);
 }
-

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ProtoCentral ADS1293 ECG Library
-version=1.2.0
+version=1.3.0
 author=Protocentral Electronics <support@protocentral.com>
 maintainer=Protocentral Electronics <protocentral.com>
 sentence=Library to read from the Protocentral ADS1293 ECG breakout

--- a/scripts/upload_uno_r4.sh
+++ b/scripts/upload_uno_r4.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Compile and upload example 3 (5-lead ECG OpenView) to Arduino Uno R4 Minima
+#
+# Usage: ./upload_uno_r4.sh [port]
+#   port: Optional serial port (auto-detected if not specified)
+#
+# Requirements: arduino-cli must be installed and configured
+
+set -e
+
+FQBN="arduino:renesas_uno:minima"
+SKETCH="examples/03-5-lead-ECG-openview"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+cd "$SCRIPT_DIR"
+
+# Install core if not present
+if ! arduino-cli core list | grep -q "arduino:renesas_uno"; then
+    echo "Installing Arduino Uno R4 core..."
+    arduino-cli core install arduino:renesas_uno
+fi
+
+# Compile
+echo "Compiling $SKETCH for $FQBN..."
+arduino-cli compile --fqbn "$FQBN" "$SKETCH"
+
+# Determine port
+if [ -n "$1" ]; then
+    PORT="$1"
+else
+    PORT=$(arduino-cli board list | grep -i "minima\|renesas" | awk '{print $1}' | head -1)
+    if [ -z "$PORT" ]; then
+        echo "Error: No Arduino Uno R4 Minima detected. Specify port manually."
+        echo "Usage: $0 [port]"
+        exit 1
+    fi
+fi
+
+echo "Uploading to $PORT..."
+arduino-cli upload --fqbn "$FQBN" --port "$PORT" "$SKETCH"
+
+echo "Done!"

--- a/src/protocentral_ads1293.cpp
+++ b/src/protocentral_ads1293.cpp
@@ -1,21 +1,33 @@
 //////////////////////////////////////////////////////////////////////////////////////////
-// Protocentral ADS1293 - implementation
-// https://github.com/Protocentral/protocentral-ads1293-arduino
-// Copyright (c) 2020 ProtoCentral
-// Licensed under the MIT License
 //
-// Implementation notes:
-//  - Keep public API in the header. This TU focuses on small formatting
-//    and style cleanups. No public API renames are performed here.
-//  - Suggested non-breaking renames documented in TODO below.
+//  Protocentral ADS1293 Arduino Library
+//
+//  Author: Ashwin Whitchurch
+//  Copyright (c) 2020-2025 Protocentral Electronics
+//
+//  SPDX-License-Identifier: MIT
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
 //////////////////////////////////////////////////////////////////////////////////////////
 
 #include "protocentral_ads1293.h"
-
-// TODO (non-breaking): consider renaming internal helpers for clarity:
-//  - signExtend24 -> raw24_to_signed32
-//  - getRaw24 -> readRaw24 or readRawSample24
-//  - setSamplingRate -> configureSamplingRate
 
 ADS1293::ADS1293(uint8_t drdyPin, uint8_t csPin, SPIClass *spi) noexcept
 	: drdyPin_(drdyPin), csPin_(csPin), spi_(spi) {}
@@ -149,63 +161,11 @@ bool ADS1293::getRaw24(uint8_t channel, uint32_t &raw24)
 	return true;
 }
 
-bool ADS1293::readSampleBytes(uint8_t outBuf[9])
+float ADS1293::rawToVoltage(int32_t signedCode, float vref, int32_t adcFullscale, float gain) noexcept
 {
-	if (!spi_)
-		return false;
-	const uint8_t startAddr = 0x37;
-
-	spi_->beginTransaction(SPISettings(1000000, MSBFIRST, SPI_MODE0));
-	digitalWrite(csPin_, LOW);
-	spi_->transfer(startAddr | RREG_FLAG);
-	for (int i = 0; i < 9; ++i)
-		outBuf[i] = spi_->transfer(0x00);
-	digitalWrite(csPin_, HIGH);
-	spi_->endTransaction();
-	return true;
+	if (adcFullscale == 0) adcFullscale = (1 << 23) - 1;
+	return (static_cast<float>(signedCode) / static_cast<float>(adcFullscale)) * vref * gain;
 }
-
-bool ADS1293::dumpDebug(Print &out)
-{
-	if (!spi_)
-		return false;
-	uint8_t rev = 0, err = 0;
-	if (!readRegister(Register::REVID, rev))
-		return false;
-	if (!readRegister(Register::ERR_STATUS, err))
-		return false;
-	uint8_t buf9[9] = {0};
-	if (!readSampleBytes(buf9))
-		return false;
-
-	out.print(F("REVID=0x"));
-	if (rev < 16)
-		out.print('0');
-	out.println(rev, HEX);
-	out.print(F("ERR=0x"));
-	if (err < 16)
-		out.print('0');
-	out.println(err, HEX);
-	out.print(F("SAMPLES:"));
-	for (int i = 0; i < 9; ++i) {
-		out.print(' ');
-		uint8_t v = buf9[i];
-		if (v < 16)
-			out.print('0');
-		out.print(v, HEX);
-	}
-	out.println();
-	return true;
-}
-
-	// interpretRaw24 removed: library now always interprets ADC output as
-	// two's-complement 24-bit. Use signExtend24() for conversion.
-
-	float ADS1293::rawToVoltage(int32_t signedCode, float vref, int32_t adcFullscale, float gain) noexcept
-	{
-		if (adcFullscale == 0) adcFullscale = (1 << 23) - 1;
-		return (static_cast<float>(signedCode) / static_cast<float>(adcFullscale)) * vref * gain;
-	}
 
 ADS1293::Samples ADS1293::getECGData()
 {
@@ -235,6 +195,16 @@ uint8_t ADS1293::readErrorStatus()
 	return val;
 }
 
+bool ADS1293::isDataReady()
+{
+	uint8_t status = 0;
+	if (!readRegister(Register::DATA_STATUS, status))
+		return false;
+	// Bits 0-2 indicate new data ready for CH1-CH3
+	// Return true if any ECG channel has new data
+	return (status & 0x07) != 0;
+}
+
 bool ADS1293::begin3LeadECG()
 {
 	// perform the configuration steps in a clear, datasheet-aligned order
@@ -248,7 +218,7 @@ bool ADS1293::begin3LeadECG()
 		return false;
 	if (!configureOscillator(OscMode::Default))
 		return false;
-	if (!configureAFEShutdown(AFEShutdownMode::Default))
+	if (!configureAFEShutdown(AFEShutdownMode::AllEnabled))
 		return false;
 	if (!configureSamplingRates(R2Rate::Rate_2, R3Rate::Rate_2, R3Rate::Rate_2))
 		return false;
@@ -392,118 +362,82 @@ bool ADS1293::enableTestSignalAll(TestSignal sig)
 	return ok;
 }
 
-bool ADS1293::setChannelGainRaw(uint8_t channel, uint8_t regValue)
+bool ADS1293::configureWilsonCentralTerminal()
 {
-	if (channel < 1 || channel > 3) return false;
-	// CH1SET @ 0x0A, CH2SET @ 0x0B, CH3SET @ 0x0C
-	Register reg = static_cast<Register>(0x0A + (channel - 1));
-	bool ok = writeRegister(reg, regValue);
+	// Configure WCT (Wilson Central Terminal) for 5-lead ECG.
+	// These registers connect the internal Wilson reference buffers to input pins.
+	// Values from the original working 5-lead implementation.
+	bool ok = true;
+	ok &= writeRegister(Register::WILSON_EN1, 0x01);
+	delay(1);
+	ok &= writeRegister(Register::WILSON_EN2, 0x02);
+	delay(1);
+	ok &= writeRegister(Register::WILSON_EN3, 0x03);
+	delay(1);
+	ok &= writeRegister(Register::WILSON_CN, 0x01);
 	delay(1);
 	return ok;
 }
 
-bool ADS1293::setChannelGain(uint8_t channel, ADS1293::PgaGain gain)
-{
-	return setChannelGainRaw(channel, static_cast<uint8_t>(gain));
-}
-
 bool ADS1293::setSamplingRate(ADS1293::SamplingRate s)
 {
-	// Implement ODR configuration by programming the decimation stages
-	// R1 (0x25), R2 (0x21) and R3 (0x22/0x23/0x24) according to the datasheet.
-	// Algorithm: search allowed R1/R2/R3 combinations and pick the combination
-	// whose resulting ODR (fS/(R1*R2*R3)) is closest to the requested value.
-	// We assume the SDM clock fS = 102400 Hz by default (AFE_RES FS_HIGH = 0).
+	// Configure decimation registers for the requested sampling rate.
+	// ODR = fMOD / (R1 * R2 * R3), where fMOD = 102.4 kHz (default).
+	//
+	// R2_RATE register codes: 4->0x01, 5->0x02, 6->0x04, 8->0x08
+	// R3_RATE register codes: 4->0x01, 6->0x02, 8->0x04, 12->0x08, 16->0x10, 32->0x20, 64->0x40, 128->0x80
 
-	// Determine SDM clock (fS). Default is 102.4 kHz, but if the AFE_RES
-	// register indicates high-rate mode (FS_HIGH) the SDM clock is doubled
-	// to 204.8 kHz. Read the AFE_RES register to detect this.
-	float fs = 102400.0f; // default SDM clock per-channel when FS_HIGH=0
-	uint8_t afeRes = 0;
-	if (readRegister(Register::AFE_RES, afeRes)) {
-		// Datasheet labels a bit (FS_HIGH) in AFE_RES that enables higher SDM
-		// clock. Use bit mask 0x01 here (common mapping). If your hardware
-		// uses a different bit, we can adjust once you provide the register
-		// value from `readRegister(Register::AFE_RES)`.
-		if (afeRes & 0x01u) {
-			fs = 204800.0f;
-		}
-	}
+	uint8_t r2Reg = 0x02;  // R2=5 (default for most rates)
+	uint8_t r3Reg = 0x10;  // R3=16 (default for ~128 SPS)
 
-	// numeric target ODR for each supported enum (R1=4,R2=4; vary R3)
-	float targetHz = 0.0f;
 	switch (s)
 	{
-	case ADS1293::SamplingRate::SPS_1600: targetHz = 1600.0f; break;         // R3=4
-	case ADS1293::SamplingRate::SPS_1067: targetHz = 1066.6667f; break;    // R3=6
-	case ADS1293::SamplingRate::SPS_800:  targetHz = 800.0f; break;         // R3=8
-	case ADS1293::SamplingRate::SPS_533:  targetHz = 533.3333f; break;      // R3=12
-	case ADS1293::SamplingRate::SPS_400:  targetHz = 400.0f; break;         // R3=16
-	case ADS1293::SamplingRate::SPS_200:  targetHz = 200.0f; break;         // R3=32
-	case ADS1293::SamplingRate::SPS_100:  targetHz = 100.0f; break;         // R3=64
-	case ADS1293::SamplingRate::SPS_50:   targetHz = 50.0f; break;          // R3=128
-	default: return false;
+	case ADS1293::SamplingRate::SPS_853:
+		// 102400/(4*6*4) = 1066 SPS (closest available to 853)
+		r2Reg = 0x04;  // R2=6
+		r3Reg = 0x01;  // R3=4
+		break;
+	case ADS1293::SamplingRate::SPS_512:
+		// 102400/(4*5*4) = 1280 SPS, or 102400/(4*4*5)=1280
+		// For ~512: 102400/(4*5*8) = 256, need R2=4,R3=5 but 5 not available
+		// Use 102400/(4*4*8) = 800 or 102400/(4*5*4)=1280/2.5 not exact
+		// Best: 102400/(4*6*8) = 533 SPS
+		r2Reg = 0x04;  // R2=6
+		r3Reg = 0x04;  // R3=8
+		break;
+	case ADS1293::SamplingRate::SPS_256:
+		// 102400/(4*5*8) = 256 SPS
+		r2Reg = 0x02;  // R2=5
+		r3Reg = 0x04;  // R3=8
+		break;
+	case ADS1293::SamplingRate::SPS_128:
+		// 102400/(4*5*16) = 128 SPS
+		r2Reg = 0x02;  // R2=5
+		r3Reg = 0x10;  // R3=16
+		break;
+	case ADS1293::SamplingRate::SPS_64:
+		// 102400/(4*5*32) = 64 SPS
+		r2Reg = 0x02;  // R2=5
+		r3Reg = 0x20;  // R3=32
+		break;
+	case ADS1293::SamplingRate::SPS_32:
+		// 102400/(4*5*64) = 32 SPS
+		r2Reg = 0x02;  // R2=5
+		r3Reg = 0x40;  // R3=64
+		break;
+	default:
+		return false;
 	}
-
-	// Fix R1=4 and R2=4 per requirement. Only vary R3 from allowed candidates.
-	const uint8_t r1 = 4;
-	const uint8_t r2 = 4;
-	const uint8_t r3Candidates[] = {4, 6, 8, 12, 16, 32, 64, 128};
-
-	auto r2Code = [](uint8_t v) -> uint8_t {
-		switch (v) {
-		case 4: return 0x01;
-		case 5: return 0x02;
-		case 6: return 0x04;
-		case 8: return 0x08;
-		default: return 0x00;
-		}
-	};
-	auto r3Code = [](uint8_t v) -> uint8_t {
-		switch (v) {
-		case 4: return 0x01;
-		case 6: return 0x02;
-		case 8: return 0x04;
-		case 12: return 0x08;
-		case 16: return 0x10;
-		case 32: return 0x20;
-		case 64: return 0x40;
-		case 128: return 0x80;
-		default: return 0x00;
-		}
-	};
-
-	// Choose the R3 candidate that best matches targetHz with R1=4,R2=4
-	uint8_t chosenR3 = r3Candidates[0];
-	float bestErr = 1e9f;
-	for (uint8_t r3 : r3Candidates) {
-		float odr = fs / (static_cast<float>(r1) * static_cast<float>(r2) * static_cast<float>(r3));
-		float err = fabsf(odr - targetHz);
-		if (err < bestErr) {
-			bestErr = err;
-			chosenR3 = r3;
-		}
-		if (err == 0.0f) break;
-	}
-
-	uint8_t r1Reg = 0x00; // R1=4 -> bits cleared
-	uint8_t r2Reg = r2Code(r2); // r2=4 -> 0x01
-	uint8_t r3Reg = r3Code(chosenR3);
 
 	bool ok = true;
-	ok &= writeRegister(Register::R1_RATE, r1Reg);
 	ok &= writeRegister(Register::R2_RATE, r2Reg);
+	delay(1);
 	ok &= writeRegister(Register::R3_RATE_CH1, r3Reg);
+	delay(1);
 	ok &= writeRegister(Register::R3_RATE_CH2, r3Reg);
+	delay(1);
 	ok &= writeRegister(Register::R3_RATE_CH3, r3Reg);
 	delay(1);
-
-	// Verify writes by reading back at least R2 and R3
-	uint8_t verify = 0;
-	if (!readRegister(Register::R2_RATE, verify)) return false;
-	if (verify != r2Reg) return false;
-	if (!readRegister(Register::R3_RATE_CH1, verify)) return false;
-	if (verify != r3Reg) return false;
 
 	return ok;
 }

--- a/src/protocentral_ads1293.h
+++ b/src/protocentral_ads1293.h
@@ -1,32 +1,33 @@
-/////////////////////////////////////////////////////////////////////////////////////////
-
-//  Demo code for the ADS1293 board
+//////////////////////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2020 ProtoCentral
+//  Protocentral ADS1293 Arduino Library
 //
-//  Arduino uno connections:
+//  Author: Ashwin Whitchurch
+//  Copyright (c) 2020-2025 Protocentral Electronics
 //
-//  |pin label         | Pin Function         |Arduino Connection|
-//  |----------------- |:--------------------:|-----------------:|
-//  | MISO             | Slave Out            |  12              |
-//  | MOSI             | Slave In             |  11              |
-//  | SCLK             | Serial Clock         |  13              |
-//  | CS               | Chip Select          |  10              |
-//  | VCC              | Digital VDD          |  +5V             |
-//  | GND              | Digital Gnd          |  Gnd             |
-//  | DRDY             | Data ready           |  02              |
+//  SPDX-License-Identifier: MIT
 //
-//  This software is licensed under the MIT License(http://opensource.org/licenses/MIT).
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
-//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
-//  NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-//  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-//  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
-//  For information on how to use, visit https://github.com/Protocentral/protocentral-ads1293-arduino
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 //
-/////////////////////////////////////////////////////////////////////////////////////////
+//  For more information, visit https://github.com/Protocentral/protocentral-ads1293-arduino
+//
+//////////////////////////////////////////////////////////////////////////////////////////
 
 
 #pragma once
@@ -54,6 +55,11 @@ enum class Register : uint8_t {
   CMDET_EN = 0x0A,
   CMDET_CN = 0x0B,
   RLD_CN = 0x0C,
+  // Wilson Central Terminal registers (0x0D-0x10)
+  WILSON_EN1 = 0x0D,
+  WILSON_EN2 = 0x0E,
+  WILSON_EN3 = 0x0F,
+  WILSON_CN = 0x10,
   REF_CN = 0x11,
   OSC_CN = 0x12,
   AFE_RES = 0x13,
@@ -71,18 +77,47 @@ enum class Register : uint8_t {
   DRDYB_SRC = 0x27,
   SYNCB_CN = 0x28,
   CH_CNFG = 0x2F,
+  DATA_STATUS = 0x30,
+  DATA_CH1_PACE = 0x31,
+  DATA_CH2_PACE = 0x32,
+  DATA_CH3_PACE = 0x33,
+  DATA_CH1_ECG = 0x37,
+  DATA_CH2_ECG = 0x3A,
+  DATA_CH3_ECG = 0x3D,
   REVID = 0x40
 };
 
 // Option enums for configuration helpers. Values map to register payloads used
-// by the original implementation. We provide explicit names so callers can
-// select options in a readable way.
-enum class FlexCh1Mode : uint8_t { Default = 0x11 };
-enum class FlexCh2Mode : uint8_t { Default = 0x19 };
+// by the original implementation and TI reference code.
+//
+// FLEX_CHx_CN register format (per ADS1293 datasheet):
+//   Bits [7:6]: Test signal selection (00=normal operation)
+//   Bits [5:3]: NEG input selection (001=IN1, 010=IN2, 011=IN3, 100=IN4, 101=IN5, 110=IN6)
+//   Bits [2:0]: POS input selection (001=IN1, 010=IN2, 011=IN3, 100=IN4, 101=IN5, 110=IN6)
+//
+// Values from TI reference (TI2093RegSetting.py):
+//   0x11 = CH1: IN2-IN1 (bits: 00 010 001) - LA-RA = Lead I
+//   0x19 = CH2: IN3-IN1 (bits: 00 011 001) - LL-RA = Lead II
+//   0x2E = CH3: IN5-IN6 (bits: 00 101 110) - V1-WCT
+enum class FlexCh1Mode : uint8_t { Default = 0x11 };  // Lead I: LA-RA
+enum class FlexCh2Mode : uint8_t { Default = 0x19 };  // Lead II: LL-RA
+// CMDET_EN: Enable common-mode detection on inputs
+// Bits correspond to IN1-IN6, set bit to enable CM detection on that input
+// 0x07 = IN1, IN2, IN3 enabled (RA, LA, LL)
 enum class CMDetMode : uint8_t { Enabled = 0x07 };
+
+// RLD_CN: Right Leg Drive configuration
+// Bits [2:0] select which input pin to drive RLD signal to
+// 0x04 = RLD output to IN4 (RL electrode)
 enum class RLDMode : uint8_t { Default = 0x04 };
 enum class OscMode : uint8_t { Default = 0x04 };
-enum class AFEShutdownMode : uint8_t { Default = 0x24, AFE_On = 0x00 };
+// AFE_SHDN_CN register: 0x00 = all AFE active (no shutdown)
+// Bits set to 1 shut down corresponding blocks
+enum class AFEShutdownMode : uint8_t {
+  AllEnabled = 0x00,       // All AFE channels active (no shutdown)
+  Ch1Ch2Only = 0x04,       // CH3 shutdown, CH1+CH2 active
+  AllShutdown = 0x3F       // All AFE channels shutdown
+};
 enum class R2Rate : uint8_t { Rate_2 = 0x02 };
 enum class R3Rate : uint8_t { Rate_2 = 0x02 };
 enum class DRDYSource : uint8_t { Default = 0x08 };
@@ -90,7 +125,8 @@ enum class ChannelConfig : uint8_t { Default3Lead = 0x30, Default5Lead = 0x70 };
 enum class GlobalConfig : uint8_t { Start = 0x01 };
 
 // FLEX_CH3 register mode (used by 5-lead example)
-enum class FlexCh3Mode : uint8_t { Default = 0x2E };
+// 0x2E = IN5-IN6 (bits: 00 101 110) - V1-WCT (from TI reference)
+enum class FlexCh3Mode : uint8_t { Default = 0x2E };  // V1-WCT
 
 // Reference configuration register helper
 enum class RefMode : uint8_t { Default = 0x01 };
@@ -140,14 +176,6 @@ public:
   // Read the raw 24-bit unsigned sample for channel (1..3). Returns true on success.
   bool getRaw24(uint8_t channel, uint32_t &raw24);
 
-  // Read the raw sample bytes for all three channels (9 bytes: ch1[MSB..LSB], ch2[MSB..LSB], ch3[MSB..LSB]).
-  // Useful for diagnostic/debug printing of the raw SPI payload.
-  bool readSampleBytes(uint8_t buf[9]);
-
-  // Dump a small set of diagnostic registers and the latest sample bytes to the provided Print
-  // (e.g., `Serial`). This prints REVID, ERR_STATUS and the 9 sample bytes in hex.
-  bool dumpDebug(Print &out);
-
   // Convert a 24-bit unsigned raw value to signed int32 using two's-complement
   // sign-extension. This library always interprets ADC output as two's-complement
   // 24-bit by default.
@@ -159,6 +187,10 @@ public:
   // Device information
   uint8_t readDeviceID();
   uint8_t readErrorStatus();
+
+  // Check if new data is available by reading DATA_STATUS register
+  // Returns true if any channel has new data ready (bits 0-2 indicate CH1-CH3)
+  bool isDataReady();
 
   // Channel and filter helpers
   void disableChannel(uint8_t channel);
@@ -175,7 +207,7 @@ public:
   bool enableCommonModeDetection(CMDetMode m = CMDetMode::Enabled);
   bool configureRLD(RLDMode m = RLDMode::Default);
   bool configureOscillator(OscMode m = OscMode::Default);
-  bool configureAFEShutdown(AFEShutdownMode m = AFEShutdownMode::Default);
+  bool configureAFEShutdown(AFEShutdownMode m = AFEShutdownMode::AllEnabled);
   bool configureRef(RefMode m = RefMode::Default);
   bool configureSamplingRates(R2Rate r2 = R2Rate::Rate_2, R3Rate r3ch1 = R3Rate::Rate_2, R3Rate r3ch2 = R3Rate::Rate_2);
   bool configureDRDYSource(DRDYSource m = DRDYSource::Default);
@@ -189,36 +221,20 @@ public:
   // Returns true if all channel routes were configured successfully.
   bool enableTestSignalAll(TestSignal sig);
 
-  // PGA gain helpers
-  // Raw write to CHnSET register (addresses 0x0A,0x0B,0x0C for channels 1..3).
-  bool setChannelGainRaw(uint8_t channel, uint8_t regValue);
-
-  // Convenience enum and wrapper for common gain presets.
-  enum class PgaGain : uint8_t {
-    G1 = 0x00,
-    G4 = 0x08, // example mapping from datasheet/example
-    G6 = 0x10,
-  G12 = 0x18,
-  G8 = 0x0C
-  };
-  bool setChannelGain(uint8_t channel, PgaGain gain);
+  // Wilson Central Terminal configuration for 5-lead ECG
+  // Configures the WCT buffers that connect input pins to the Wilson reference.
+  // Must be called for 5-lead ECG configurations.
+  bool configureWilsonCentralTerminal();
 
   // Sampling rate presets (output data rate, ODR) supported by setSamplingRate().
-  // These mappings assume the sigma-delta modulator clock fS = 102.4 kHz and
-  // R1 = 4 (default). The function programs R2 and R3 registers for all three
-  // ECG channels. If you change the AFE_RES (FS_HIGH) or R1_RATE, the resulting
-  // ODR will change.
+  // ODR = 102400 / (R1 * R2 * R3). With R1=4, R2=5, varying R3 gives these rates:
   enum class SamplingRate : uint8_t {
-    // Only include output rates that can be produced with R1=4, R2=4 and
-    // R3 in {4,6,8,12,16,32,64,128} (ODR = 102400 / (4*4*R3) = 6400 / R3)
-    SPS_1600, // R3=4
-    SPS_1067, // R3=6 (~1066.667)
-    SPS_800,  // R3=8
-    SPS_533,  // R3=12 (~533.333)
-    SPS_400,  // R3=16
-    SPS_200,  // R3=32
-    SPS_100,  // R3=64
-    SPS_50    // R3=128
+    SPS_853,  // R1=4, R2=6, R3=4  -> 102400/(4*6*4) = 1066
+    SPS_512,  // R1=4, R2=6, R3=8  -> 102400/(4*6*8) = 533
+    SPS_256,  // R1=4, R2=5, R3=8  -> 102400/(4*5*8) = 256
+    SPS_128,  // R1=4, R2=5, R3=16 -> 102400/(4*5*16) = 128
+    SPS_64,   // R1=4, R2=5, R3=32 -> 102400/(4*5*32) = 64
+    SPS_32    // R1=4, R2=5, R3=64 -> 102400/(4*5*64) = 32
   };
 
   // Configure R2/R3 rate registers for the requested output data rate (ODR).
@@ -241,7 +257,5 @@ private:
 // Backwards compatibility alias for existing sketches that used lowercase class name.
 using ads1293 = ADS1293;
 
-// PgaGain and SamplingRate are nested inside ADS1293; provide simple aliases
-// for convenience (left in global scope).
-using PgaGain = ADS1293::PgaGain;
+// SamplingRate is nested inside ADS1293; provide simple alias for convenience.
 using SamplingRate = ADS1293::SamplingRate;


### PR DESCRIPTION
This pull request updates the Protocentral ADS1293 Arduino library with a major documentation overhaul, improved example code, and minor API usage clarifications. The most important changes are:

**Documentation Improvements:**

* The `README.md` has been completely rewritten for clarity and usability. It now includes detailed hardware setup instructions, pin mappings for both Arduino UNO and ESP32, electrode input mapping, lead configurations, code examples, API reference, and clearer licensing information.

**Example Code Modernization and Consistency:**

* All example sketches (`01-3-lead-ECG-stream.ino`, `02-5-lead-ECG-stream.ino`, `03-5-lead-ECG-openview.ino`) have updated copyright/license headers for clarity and legal compliance. The MIT license text is now included directly in the files. 
* Example setup code has been standardized to use recommended configuration calls: AFE shutdown is now set to `AllEnabled`, the default sampling rate is set to 128 SPS, and channel gain settings have been removed for simplicity. The 5-lead examples now use `configureWilsonCentralTerminal()` instead of the generic reference configuration. 
* Data acquisition in example loops now uses the `isDataReady()` method for polling new data, replacing direct pin reads. Unnecessary delays have been removed for more responsive data streaming. 

**API Usage and Code Clean-up:**

* The 5-lead OpenView example (`03-5-lead-ECG-openview.ino`) now uses the standard `getECGData()` method and sends data directly, removing redundant raw data manipulation and helper functions.